### PR TITLE
bring back sharing

### DIFF
--- a/main.js
+++ b/main.js
@@ -577,10 +577,6 @@ function load_legacy(){
 	if(h) restorestate(JSON.parse(atob(h)));
 }
 
-function share(){
-	var h = btoa(JSON.stringify(getstate()));
-}
-
 grab("save").onclick = save;
 
 /* main() :D */

--- a/main.js
+++ b/main.js
@@ -538,7 +538,9 @@ function getstate(){
 var saved = false;
 function save(){
 	window.localStorage.setItem('state', JSON.stringify(getstate()));
+	window.location.hash = btoa(JSON.stringify(getstate()));
 	alert("your settings are saved in your browser.");
+	alert("your settings are also saved in the link for you to copy and share your schedule.");
 	saved = true;
 }
 /* this does not errorcheck because there is no point providing feedback if someone put garbage in localStorage. */
@@ -575,12 +577,16 @@ function load_legacy(){
 	if(h) restorestate(JSON.parse(atob(h)));
 }
 
+function share(){
+	var h = btoa(JSON.stringify(getstate()));
+}
+
 grab("save").onclick = save;
 
 /* main() :D */
 grab("fdate").innerHTML += window.fdate;
-if(window.localStorage.getItem('state')) load();
-else if(window.location.hash) load_legacy();
+if(window.location.hash) load_legacy();
+else if(window.localStorage.getItem('state')) load();
 draw();
 
 /* current opaque */


### PR DESCRIPTION
This PR:
- brings back url sharing while also keeping the schedule in your browser's local storage. 
- changes default setting to check for the url hash first, then local storage.

This way you can share your settings with people, view theirs in your browser like the good old times and still easily access your settings in your browser on `tetick.xyz`.